### PR TITLE
Change method for using zero-copy

### DIFF
--- a/examples/arp_response.rs
+++ b/examples/arp_response.rs
@@ -3,9 +3,12 @@
 use packetvisor::pv;
 use pnet::{
     datalink::{interfaces, MacAddr, NetworkInterface},
-    packet::arp::{ArpHardwareTypes, ArpOperations, MutableArpPacket},
     packet::ethernet::{EtherTypes, MutableEthernetPacket},
     packet::MutablePacket,
+    packet::{
+        arp::{ArpHardwareTypes, ArpOperations, MutableArpPacket},
+        PacketSize,
+    },
 };
 use signal_hook::SigId;
 use std::{
@@ -188,5 +191,6 @@ fn make_arp_response_packet(src_mac_addr: &MacAddr, packet: &mut pv::Packet) {
     arp_req.set_target_hw_addr(dest_mac_addr);
     arp_req.set_target_proto_addr(dest_ipv4_addr);
 
-    packet.end = packet.start + 42; // minimum ARP packet size
+    let packet_size = (arp_req.packet_size() + eth_pkt.packet_size()) as u32;
+    packet.end = packet.start + packet_size;
 }

--- a/examples/arp_response.rs
+++ b/examples/arp_response.rs
@@ -166,7 +166,7 @@ fn is_arp_req(packet: &pv::Packet) -> bool {
 }
 
 fn make_arp_response_packet(src_mac_addr: &MacAddr, packet: &mut pv::Packet) {
-    let mut buffer = packet.get_buffer();
+    let mut buffer = packet.get_buffer_mut();
 
     let mut eth_pkt = MutableEthernetPacket::new(&mut buffer).unwrap();
     let dest_mac_addr: MacAddr = eth_pkt.get_source();

--- a/examples/arp_response.rs
+++ b/examples/arp_response.rs
@@ -166,7 +166,7 @@ fn is_arp_req(packet: &pv::Packet) -> bool {
 }
 
 fn make_arp_response_packet(src_mac_addr: &MacAddr, packet: &mut pv::Packet) {
-    let mut buffer: &mut [u8] = packet.get_buffer();
+    let mut buffer = packet.get_buffer();
 
     let mut eth_pkt = MutableEthernetPacket::new(&mut buffer).unwrap();
     let dest_mac_addr: MacAddr = eth_pkt.get_source();

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -55,15 +55,13 @@ impl Packet {
         }
     }
 
-    pub fn get_buffer(&mut self) -> &mut [u8] {
-        let buffer = unsafe {
+    pub fn get_buffer_mut(&mut self) -> &mut [u8] {
+        unsafe {
             std::slice::from_raw_parts_mut(
                 self.buffer.offset(self.start as isize),
                 (self.end - self.start) as usize,
             )
-        };
-
-        buffer
+        }
     }
 }
 

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -8,7 +8,6 @@ mod bindings {
 }
 
 use bindings::*;
-
 use core::ffi::*;
 use pnet::datalink::{interfaces, NetworkInterface};
 use std::alloc::{alloc_zeroed, Layout};

--- a/src/pv.rs
+++ b/src/pv.rs
@@ -37,7 +37,7 @@ impl Packet {
         }
     }
 
-    // replace payload with new data, and return Ok(remaining size) or Err(excess size) if failed
+    // replace payload with new data
     pub fn replace_data(&mut self, new_data: &Vec<u8>) -> Result<(), String> {
         if new_data.len() as u32 <= self.buffer_size {
             unsafe {
@@ -55,14 +55,13 @@ impl Packet {
         }
     }
 
-    pub fn get_buffer(&self) -> Vec<u8> {
+    pub fn get_buffer(&mut self) -> &mut [u8] {
         let buffer = unsafe {
-            std::slice::from_raw_parts(
+            std::slice::from_raw_parts_mut(
                 self.buffer.offset(self.start as isize),
                 (self.end - self.start) as usize,
             )
-        }
-        .to_owned();
+        };
 
         buffer
     }


### PR DESCRIPTION
The commit fixes Issue #51.

method `get_buffer()` is changed with `get_buffer_mut()` and it will make packet processing able to use zero-copy.

`arp_example.rs` is also changed to use `get_buffer_mut()`
